### PR TITLE
Upstream fix poco build

### DIFF
--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -334,8 +334,7 @@ fi
 if [ ! -d $poco_dir ]; then
   #Fix for poco_version being unset after Lo compilation? TODO: Check the case
   [ -z "${poco_version}" ] && poco_version=$(curl -s https://pocoproject.org/ | grep -oiE 'The latest stable release is [0-9+]\.[0-9\.]{1,}[0-9]{1,}' | awk '{print $NF}')
-  [ ! -f $(dirname $poco_dir)/poco-${poco_version}-all.tar.gz ] &&\
-  wget -c https://pocoproject.org/releases/poco-${poco_version}/poco-${poco_version}-all.tar.gz -P $(dirname $poco_dir)/  || exit 3
+  wget -c https://pocoproject.org/releases/poco-${poco_version}/poco-${poco_version}-all.tar.gz -P $(dirname $poco_dir)/ || exit 3
   tar xf $(dirname $poco_dir)/poco-${poco_version}-all.tar.gz -C  $(dirname $poco_dir)/
   chown lool:lool $poco_dir -R
 fi


### PR DESCRIPTION
Here exit 3 fired if poco file downloaded but not builded.
Skip check for file - wget result or skip download.